### PR TITLE
One gemma cli

### DIFF
--- a/bin/get_gemma_meta.py
+++ b/bin/get_gemma_meta.py
@@ -8,8 +8,8 @@ import gemmapy
 def argument_parser():
     parser = argparse.ArgumentParser(description="Preprocess data from GEMMA")
     parser.add_argument("--study_name", type=str, help="Name of the study", default="GSE152715.1")
-    parser.add_argument('--gemma_username', type=str, default="raschwar")
-    parser.add_argument('--gemma_password', type=str, default="7nddtt")
+    parser.add_argument('--gemma_username', type=str, default=None)
+    parser.add_argument('--gemma_password', type=str, default=None)
     return parser.parse_args()
 
 def main():

--- a/modules/local/combine_cta/main.nf
+++ b/modules/local/combine_cta/main.nf
@@ -1,5 +1,5 @@
 process COMBINE_CTA {
-    tag "$study_name"
+    tag "$study_name GEMMA_CLI_TASK"
     // label 'process_single'
 
     input:

--- a/modules/local/load_clc/main.nf
+++ b/modules/local/load_clc/main.nf
@@ -1,5 +1,5 @@
 process LOAD_CLC {
-    tag "$study_name"
+    tag "$study_name GEMMA_CLI_TASK"
     // label 'process_single'
 
     input:

--- a/modules/local/load_mask/main.nf
+++ b/modules/local/load_mask/main.nf
@@ -1,5 +1,5 @@
 process LOAD_MASK {
-    tag "$study_name"
+    tag "$study_name GEMMA_CLI_TASK"
     // label 'process_single'
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -185,6 +185,12 @@ process.executor       = 'slurm'
 process.clusterOptions = '-C thrd64 --cpus-per-task=8 --mem=32G'
 executor.queueSize     = 25
 
+process {
+    withName: LOAD_CTA LOAD_CLC LOAD_MASK{
+        maxForks = 1
+    }
+}
+
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
 env {
     PYTHONNOUSERSITE = 1

--- a/nextflow.config
+++ b/nextflow.config
@@ -186,7 +186,7 @@ process.clusterOptions = '-C thrd64 --cpus-per-task=8 --mem=32G'
 executor.queueSize     = 25
 
 process {
-    withName: LOAD_CTA LOAD_CLC LOAD_MASK{
+    withTag: GEMMA_CLI_TASK{
         maxForks = 1
     }
 }


### PR DESCRIPTION
This pull request introduces a new process tag, `GEMMA_CLI_TASK`, to several pipeline modules and updates the Nextflow configuration to limit parallel execution for processes with this tag. These changes help ensure that specific tasks are run with controlled concurrency, likely to avoid resource conflicts or improve stability.

Tagging processes for controlled execution:

* `modules/local/combine_cta/main.nf`, `modules/local/load_clc/main.nf`, `modules/local/load_mask/main.nf`: Added `GEMMA_CLI_TASK` to the process tags, allowing these processes to be targeted for special execution rules. [[1]](diffhunk://#diff-c163962d814d13d3ca348335b3e49242f52231b647ba26c6ba422bf6b12950efL2-R2) [[2]](diffhunk://#diff-b73b3e3fbb5c32b714828050484b311817385da3bff77b4de17b4bd97882a006L2-R2) [[3]](diffhunk://#diff-74a289a812b02de828e9c6a2b24198ef40adfd525c30e2d47f02395f0665a08dL2-R2)

Nextflow configuration for tagged processes:

* [`nextflow.config`](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaR188-R193): Added a configuration block that sets `maxForks = 1` for any process tagged with `GEMMA_CLI_TASK`, ensuring only one instance runs at a time.